### PR TITLE
Rename *Def types to shortened versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ styledChart.renderTo(canvas.getContext2D())
 
 ```scala
 val chart = lineChart("My Chart")
-  .withXAxis(AxisDef.CategoryScale("Month", categories = Some(Vector("Jan", "Feb", "Mar", "Apr"))))
-  .withYAxis(AxisDef.LinearScale("Value", Some(0.0), Some(100.0)))
+  .withXAxis(Axis.CategoryScale("Month", categories = Some(Vector("Jan", "Feb", "Mar", "Apr"))))
+  .withYAxis(Axis.LinearScale("Value", Some(0.0), Some(100.0)))
 ```
 
 ### Multiple Series
@@ -115,23 +115,23 @@ val salesData = Vector(
 val chart = lineChart(
   "Sales Performance",
   genericSeries[SalesData](
-    "Revenue", 
-    salesData, 
+    "Revenue",
+    salesData,
     // Extract x-value (convert month to numeric position)
     data => salesData.indexOf(data).toDouble + 1,
     // Extract y-value (revenue)
     data => data.revenue
   ),
   genericSeries[SalesData](
-    "Expenses", 
-    salesData, 
-    data => salesData.indexOf(data).toDouble + 1, 
+    "Expenses",
+    salesData,
+    data => salesData.indexOf(data).toDouble + 1,
     data => data.expenses
   ),
   genericSeries[SalesData](
-    "Profit", 
-    salesData, 
-    data => salesData.indexOf(data).toDouble + 1, 
+    "Profit",
+    salesData,
+    data => salesData.indexOf(data).toDouble + 1,
     data => data.profit
   )
 )

--- a/core/src/main/scala/florence/core/dsl/LineChartDsl.scala
+++ b/core/src/main/scala/florence/core/dsl/LineChartDsl.scala
@@ -17,7 +17,7 @@
 package florence.core.dsl
 
 import florence.core.model.*
-import florence.core.model.ChartDef.LineChart
+import florence.core.model.Chart.LineChart
 
 object LineChartDsl:
 
@@ -25,15 +25,15 @@ object LineChartDsl:
     LineChart(
       title = Some(title),
       series = series.toVector,
-      xAxis = AxisDef.LinearScale(label = "x", min = None, max = None),
-      yAxis = AxisDef.LinearScale(label = "y", min = None, max = None)
+      xAxis = Axis.LinearScale(label = "x", min = None, max = None),
+      yAxis = Axis.LinearScale(label = "y", min = None, max = None)
     )
 
   extension [A](chart: LineChart)
-    def withXAxis(axis: AxisDef): LineChart =
+    def withXAxis(axis: Axis): LineChart =
       chart.copy(xAxis = axis)
 
-    def withYAxis(axis: AxisDef): LineChart =
+    def withYAxis(axis: Axis): LineChart =
       chart.copy(yAxis = axis)
 
     def withTitle(newTitle: String): LineChart =

--- a/core/src/main/scala/florence/core/dsl/styling/ChartStylingDsl.scala
+++ b/core/src/main/scala/florence/core/dsl/styling/ChartStylingDsl.scala
@@ -18,12 +18,12 @@ package florence.core.dsl.styling
 
 import florence.core.model.*
 import florence.core.model.styling.*
-import florence.core.model.styling.ChartStyleDef.LineChartStyle
+import florence.core.model.styling.ChartStyle.LineChartStyle
 
 object ChartStylingDsl:
 
   export LineChartStylingDsl.*
 
-  extension [C <: ChartDef, S <: ChartStyleDef](chart: C)
+  extension [C <: Chart, S <: ChartStyle](chart: C)
     def withStyling(style: S): StyledChart[C, S] =
       StyledChart(chart, style)

--- a/core/src/main/scala/florence/core/dsl/styling/LineChartStylingDsl.scala
+++ b/core/src/main/scala/florence/core/dsl/styling/LineChartStylingDsl.scala
@@ -16,9 +16,9 @@
 
 package florence.core.dsl.styling
 
-import florence.core.model.ChartDef.LineChart
+import florence.core.model.Chart.LineChart
 import florence.core.model.styling.*
-import florence.core.model.styling.ChartStyleDef.LineChartStyle
+import florence.core.model.styling.ChartStyle.LineChartStyle
 
 object LineChartStylingDsl:
 

--- a/core/src/main/scala/florence/core/dsl/styling/StyledChart.scala
+++ b/core/src/main/scala/florence/core/dsl/styling/StyledChart.scala
@@ -16,12 +16,12 @@
 
 package florence.core.dsl.styling
 
-import florence.core.model.ChartDef
-import florence.core.model.ChartDef.LineChart
-import florence.core.model.styling.ChartStyleDef
-import florence.core.model.styling.ChartStyleDef.LineChartStyle
+import florence.core.model.Chart
+import florence.core.model.Chart.LineChart
+import florence.core.model.styling.ChartStyle
+import florence.core.model.styling.ChartStyle.LineChartStyle
 
-final case class StyledChart[C <: ChartDef, S <: ChartStyleDef](
+final case class StyledChart[C <: Chart, S <: ChartStyle](
     chart: C,
     style: S
 )

--- a/core/src/main/scala/florence/core/model/Chart.scala
+++ b/core/src/main/scala/florence/core/model/Chart.scala
@@ -16,13 +16,13 @@
 
 package florence.core.model
 
-enum ChartDef:
+enum Chart:
 
   case LineChart(
       title: Option[String],
       series: Vector[LineSeries],
-      xAxis: AxisDef,
-      yAxis: AxisDef
+      xAxis: Axis,
+      yAxis: Axis
   )
 
 final case class LineSeries(
@@ -35,6 +35,6 @@ enum LineData:
   case FunctionPlot(f: Double => Double, start: Double, end: Double, sampleSize: Int)
   case GenericData[A](data: Vector[A], x: A => Double, y: A => Double)
 
-enum AxisDef:
+enum Axis:
   case LinearScale(label: String, min: Option[Double], max: Option[Double])
   case CategoryScale(label: String, categories: Option[Vector[String]] = None)

--- a/core/src/main/scala/florence/core/model/styling/ChartStyle.scala
+++ b/core/src/main/scala/florence/core/model/styling/ChartStyle.scala
@@ -18,7 +18,7 @@ package florence.core.model.styling
 
 import florence.core.model.shared.StyleTypes.*
 
-enum ChartStyleDef:
+enum ChartStyle:
 
   case LineChartStyle(
       commonProps: CommonStyleProps = CommonStyleProps(),

--- a/core/src/main/scala/florence/core/model/styling/WithCommonProps.scala
+++ b/core/src/main/scala/florence/core/model/styling/WithCommonProps.scala
@@ -17,7 +17,7 @@
 package florence.core.model.styling
 
 import florence.core.model.shared.StyleTypes.*
-import florence.core.model.styling.ChartStyleDef.LineChartStyle
+import florence.core.model.styling.ChartStyle.LineChartStyle
 
 trait WithCommonProps[T]:
   def getCommonProps(t: T): CommonStyleProps
@@ -95,13 +95,13 @@ object WithCommonProps:
     ): LineChartStyle =
       style.copy(commonProps = props)
 
-  given WithCommonProps[ChartStyleDef] with
+  given WithCommonProps[ChartStyle] with
 
-    def getCommonProps(style: ChartStyleDef): CommonStyleProps = style match
+    def getCommonProps(style: ChartStyle): CommonStyleProps = style match
       case s: LineChartStyle =>
         summon[WithCommonProps[LineChartStyle]].getCommonProps(s)
 
-    def withCommonProps(style: ChartStyleDef, props: CommonStyleProps): ChartStyleDef =
+    def withCommonProps(style: ChartStyle, props: CommonStyleProps): ChartStyle =
       style match
         case s: LineChartStyle =>
           summon[WithCommonProps[LineChartStyle]].withCommonProps(s, props)

--- a/core/src/main/scala/florence/core/rendering/LineChartInterpreter.scala
+++ b/core/src/main/scala/florence/core/rendering/LineChartInterpreter.scala
@@ -20,10 +20,10 @@ import scala.collection.mutable
 
 import florence.core.dsl.styling.LineChartStylingDsl.*
 import florence.core.model.*
-import florence.core.model.ChartDef.LineChart
+import florence.core.model.Chart.LineChart
 import florence.core.model.shared.StyleTypes.*
 import florence.core.model.styling.*
-import florence.core.model.styling.ChartStyleDef.LineChartStyle
+import florence.core.model.styling.ChartStyle.LineChartStyle
 import florence.core.model.styling.WithCommonProps.*
 import florence.core.model.styling.WithCommonProps.given
 
@@ -74,12 +74,12 @@ object LineChartInterpreter:
     val (yMin, yMax)                             = computeAxisRange(chart.yAxis, dataYMin, dataYMax)
     ChartSetup(width, height, margins, xMin, xMax, yMin, yMax, plotWidth, plotHeight)
 
-  private def computeAxisRange(axis: AxisDef, dataMin: Double, dataMax: Double): (Double, Double) =
+  private def computeAxisRange(axis: Axis, dataMin: Double, dataMax: Double): (Double, Double) =
     axis match
-      case AxisDef.LinearScale(_, min, max) =>
+      case Axis.LinearScale(_, min, max) =>
         // Use provided min/max or fallback to data ranges
         (min.getOrElse(dataMin), max.getOrElse(dataMax))
-      case AxisDef.CategoryScale(_, categories) =>
+      case Axis.CategoryScale(_, categories) =>
         // Axis padding: extra 5% on both sides of the axis
         val categoryCount = categories.map(_.size).getOrElse(0)
         val padding       = Math.max(0.5, categoryCount * 0.05)
@@ -172,12 +172,12 @@ object LineChartInterpreter:
     val yLabelFont = style.yAxis.labelFont.getOrElse(FontSpec("sans-serif", 12.0, "normal"))
 
     val xAxisLabel = chart.xAxis match
-      case AxisDef.LinearScale(label, _, _) => label
-      case AxisDef.CategoryScale(label, _)  => label
+      case Axis.LinearScale(label, _, _) => label
+      case Axis.CategoryScale(label, _)  => label
 
     val yAxisLabel = chart.yAxis match
-      case AxisDef.LinearScale(label, _, _) => label
-      case AxisDef.CategoryScale(label, _)  => label
+      case Axis.LinearScale(label, _, _) => label
+      case Axis.CategoryScale(label, _)  => label
 
     result += TextOp(
       xAxisLabel,
@@ -231,11 +231,11 @@ object LineChartInterpreter:
       result: mutable.ReusableBuilder[DrawOp, Vector[DrawOp]]
   ): Unit =
     chart.xAxis match
-      case AxisDef.CategoryScale(_, Some(categories)) =>
+      case Axis.CategoryScale(_, Some(categories)) =>
         drawCategoricalXAxis(categories, setup, style, result)
-      case AxisDef.CategoryScale(_, None) =>
+      case Axis.CategoryScale(_, None) =>
         drawAutoCategoricalXAxis(setup, style, result)
-      case AxisDef.LinearScale(_, _, _) =>
+      case Axis.LinearScale(_, _, _) =>
         drawNumericXAxis(setup, style, result)
   end drawXAxisElements
 

--- a/core/src/main/scala/florence/core/rendering/Renderer.scala
+++ b/core/src/main/scala/florence/core/rendering/Renderer.scala
@@ -17,8 +17,8 @@
 package florence.core.rendering
 
 import florence.core.dsl.styling.StyledChart
-import florence.core.model.ChartDef
-import florence.core.model.styling.ChartStyleDef
+import florence.core.model.Chart
+import florence.core.model.styling.ChartStyle
 
 /** Typeclass for rendering a Drawing to a specific context/platform
   *
@@ -35,7 +35,7 @@ object Renderer:
 
 object RendererExtensions:
 
-  extension [C <: ChartDef, S <: ChartStyleDef, Ctx](chart: C)
+  extension [C <: Chart, S <: ChartStyle, Ctx](chart: C)
 
     def renderWith(style: S, context: Ctx)(using
         interpreter: Interpreter[(C, S), Drawing],
@@ -44,7 +44,7 @@ object RendererExtensions:
       val drawing = interpreter.interpret((chart, style))
       renderer.render(drawing, context)
 
-  extension [C <: ChartDef, Ctx](chart: C)
+  extension [C <: Chart, Ctx](chart: C)
 
     def renderTo(
         context: Ctx
@@ -56,7 +56,7 @@ object RendererExtensions:
     def renderTo[Ctx](context: Ctx)(using renderer: Renderer[Ctx]): Unit =
       Renderer.render(drawing, context)
 
-  extension [C <: ChartDef, S <: ChartStyleDef, Ctx](styledChart: StyledChart[C, S])
+  extension [C <: Chart, S <: ChartStyle, Ctx](styledChart: StyledChart[C, S])
 
     def renderTo(
         context: Ctx

--- a/core/src/main/scala/florence/package.scala
+++ b/core/src/main/scala/florence/package.scala
@@ -17,12 +17,12 @@
 package florence
 
 // model exports
-export florence.core.model.ChartDef
+export florence.core.model.Chart
 export florence.core.model.LineSeries
 export florence.core.model.LineData
-export florence.core.model.AxisDef
+export florence.core.model.Axis
 export florence.core.model.shared.StyleTypes.*
-export florence.core.model.styling.ChartStyleDef
+export florence.core.model.styling.ChartStyle
 export florence.core.model.styling.CommonStyleProps
 export florence.core.model.styling.BackgroundStyle
 export florence.core.model.styling.BorderStyle

--- a/sandbox/js/src/main/scala/florence/sandbox/js/Example.scala
+++ b/sandbox/js/src/main/scala/florence/sandbox/js/Example.scala
@@ -123,12 +123,12 @@ object Example:
         pointsSeries("TMin 2025", tmin2025*)
       )
         .withXAxis(
-          AxisDef.CategoryScale(
+          Axis.CategoryScale(
             "Month",
             categories = Some(Vector("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"))
           )
         )
-        .withYAxis(AxisDef.LinearScale("Temperature (°C)", None, None))
+        .withYAxis(Axis.LinearScale("Temperature (°C)", None, None))
     val style = lineChartStyle()
       .withDefaultSeriesStyle(
         LineSeriesStyle(


### PR DESCRIPTION
There's no strong reason to keep the `Def` suffix so I dropped it from `AxisDef`, `ChartDef`, and `ChartStyleDef`.