### PR TITLE
Update gitignore to ignore mill temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ metals.sbt
 
 # Techinically a duplicate of the IDEA section.
 out/
+mill.*
 
 ### Vim ###
 


### PR DESCRIPTION
This is a temporary fix because the 47 gitignore build is broken.